### PR TITLE
Add RTD theme dependency for docs build

### DIFF
--- a/docs/source/_static/.gitkeep
+++ b/docs/source/_static/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure the _static directory is tracked for Sphinx builds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "pytest-mock>=3.15.1",
     # Documentation
     "sphinx==8.1.3",
+    "sphinx-rtd-theme>=3.0.0",
     "sphinx_immaterial>=0.13.8",
     "sphinx-autodoc-typehints==3.0.1",
     "sphinx-copybutton>=0.5.2",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -105,6 +105,8 @@ sphinx==8.1.3
     #   sphinx-autodoc-typehints
     #   sphinx-copybutton
     #   sphinx-immaterial
+sphinx-rtd-theme==3.0.1
+    # via pyUSPTO (pyproject.toml)
 sphinx-autodoc-typehints==3.0.1
     # via pyUSPTO (pyproject.toml)
 sphinx-copybutton==0.5.2


### PR DESCRIPTION
## Summary
- add sphinx-rtd-theme to development dependencies for documentation builds
- include empty _static directory required by Sphinx

## Testing
- not run (package installation blocked in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938c09ad978832fb0468283e33d905b)